### PR TITLE
fix #27: correct sensor throttling for ESPHome 2025.8.0

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "25.8.19.1"
+  version: "25.8.20.1"
 
 esp32:
   board: esp32-s3-devkitc-1
@@ -90,12 +90,10 @@ output:
 
 LD2412:
   id: ld2412
-  throttle: 500ms
   uart_id: uart_bus
 ld2450:
   id: ld2450_radar
   uart_id: uart_bus2
-  throttle: 500ms
 
 button:
   - platform: restart
@@ -415,222 +413,348 @@ sensor:
     target_count:
       name: LD2450 Presence Target Count
       id: presence_target_count
+      filters:
+        - throttle: 500ms
     still_target_count:
       name: LD2450 Still Target Count
       id: ld2450_still_target_count
+      filters:
+        - throttle: 500ms
     moving_target_count:
       name: LD2450 Moving Target Count
       id: ld2450_moving_target_count
+      filters:
+        - throttle: 500ms
     target_1:
       x:
         name: LD2450 Target-1 X
         id: ld2450_target1_x
+        filters:
+          - throttle: 500ms
       y:
         name: LD2450 Target-1 Y
         id: ld2450_target1_y
+        filters:
+          - throttle: 500ms
       speed:
         name: LD2450 Target-1 Speed
         id: ld2450_target1_speed
+        filters:
+          - throttle: 500ms
       angle:
         name: LD2450 Target-1 Angle
         id: ld2450_target1_angle
+        filters:
+          - throttle: 500ms
       distance:
         name: LD2450 Target-1 Distance
         id: ld2450_target1_distance
+        filters:
+          - throttle: 500ms
       resolution:
         name: LD2450 Target-1 Resolution
         id: ld2450_target1_resolution
         disabled_by_default: true
+        filters:
+          - throttle: 500ms
     target_2:
       x:
         name: LD2450 Target-2 X
         id: ld2450_target2_x
+        filters:
+          - throttle: 500ms
       y:
         name: LD2450 Target-2 Y
         id: ld2450_target2_y
+        filters:
+          - throttle: 500ms
       speed:
         name: LD2450 Target-2 Speed
         id: ld2450_target2_speed
+        filters:
+          - throttle: 500ms
       angle:
         name: LD2450 Target-2 Angle
         id: ld2450_target2_angle
+        filters:
+          - throttle: 500ms
       distance:
         name: LD2450 Target-2 Distance
         id: ld2450_target2_distance
+        filters:
+          - throttle: 500ms
       resolution:
         name: LD2450 Target-2 Resolution
         id: ld2450_target2_resolution
         disabled_by_default: true
+        filters:
+          - throttle: 500ms
     target_3:
       x:
         name: LD2450 Target-3 X
         id: ld2450_target3_x
+        filters:
+          - throttle: 500ms
       y:
         name: LD2450 Target-3 Y
         id: ld2450_target3_y
+        filters:
+          - throttle: 500ms
       speed:
         name: LD2450 Target-3 Speed
         id: ld2450_target3_speed
+        filters:
+          - throttle: 500ms
       angle:
         name: LD2450 Target-3 Angle
         id: ld2450_target3_angle
+        filters:
+          - throttle: 500ms
       distance:
         name: LD2450 Target-3 Distance
         id: ld2450_target3_distance
+        filters:
+          - throttle: 500ms
       resolution:
         name: LD2450 Target-3 Resolution
         id: ld2450_target3_resolution
         disabled_by_default: true
+        filters:
+          - throttle: 500ms
     zone_1:
       target_count:
         name: LD2450 Zone-1 All Target Count
         id: ld2450_zone1_target_count
+        filters:
+          - throttle: 500ms
       still_target_count:
         name: LD2450 Zone-1 Still Target Count
         id: ld2450_zone1_still_target_count
+        filters:
+          - throttle: 500ms
       moving_target_count:
         name: LD2450 Zone-1 Moving Target Count
         id: ld2450_zone1_moving_target_count
+        filters:
+          - throttle: 500ms
     zone_2:
       target_count:
         name: LD2450 Zone-2 All Target Count
         id: ld2450_zone2_target_count
+        filters:
+          - throttle: 500ms
       still_target_count:
         name: LD2450 Zone-2 Still Target Count
         id: ld2450_zone2_still_target_count
+        filters:
+          - throttle: 500ms
       moving_target_count:
         name: LD2450 Zone-2 Moving Target Count
         id: ld2450_zone2_moving_target_count
+        filters:
+          - throttle: 500ms
     zone_3:
       target_count:
         name: LD2450 Zone-3 All Target Count
         id: ld2450_zone3_target_count
+        filters:
+          - throttle: 500ms
       still_target_count:
         name: LD2450 Zone-3 Still Target Count
         id: ld2450_zone3_still_target_count
+        filters:
+          - throttle: 500ms
       moving_target_count:
         name: LD2450 Zone-3 Moving Target Count
         id: ld2450_zone3_moving_target_count
+        filters:
+          - throttle: 500ms
 
   - platform: LD2412
     moving_distance:
       name : LD2412 Moving Distance
       id: ld2412_moving_distance
       disabled_by_default: true
+      filters:
+          - throttle: 500ms
     still_distance:
       name: LD2412 Still Distance
       id: ld2412_still_distance
       disabled_by_default: true
+      filters:
+        - throttle: 500ms
     moving_energy:
       name: LD2412 Move Energy
       id: ld2412_move_energy
       disabled_by_default: true
+      filters:
+        - throttle: 500ms
     still_energy:
       name: LD2412 Still Energy
       id: ld2412_still_energy
       disabled_by_default: true
+      filters:
+        - throttle: 500ms
     detection_distance:
       name: LD2412 Detection Distance
       id: ld2412_detection_distance
       disabled_by_default: true
+      filters:
+        - throttle: 500ms
     g0:
       move_energy:
         name: LD2412 g00 move energy
         id: ld2412_g00_move_energy
+        filters:
+          - throttle: 500ms
       still_energy:
         name: LD2412 g00 still energy
         id: ld2412_g00_still_energy
+        filters:
+          - throttle: 500ms
     g1:
       move_energy:
         name: LD2412 g01 move energy
         id: ld2412_g01_move_energy
+        filters:
+          - throttle: 500ms
       still_energy:
         name: LD2412 g01 still energy
         id: ld2412_g01_still_energy
+        filters:
+          - throttle: 500ms
     g2:
       move_energy:
         name: LD2412 g02 move energy
         id: ld2412_g02_move_energy
+        filters:
+          - throttle: 500ms
       still_energy:
         name: LD2412 g02 still energy
         id: ld2412_g02_still_energy
+        filters:
+          - throttle: 500ms
     g3:
       move_energy:
         name: LD2412 g03 move energy
         id: ld2412_g03_move_energy
+        filters:
+          - throttle: 500ms
       still_energy:
         name: LD2412 g03 still energy
         id: ld2412_g03_still_energy
+        filters:
+          - throttle: 500ms
     g4:
       move_energy:
         name: LD2412 g04 move energy
         id: ld2412_g04_move_energy
+        filters:
+          - throttle: 500ms
       still_energy:
         name: LD2412 g04 still energy
         id: ld2412_g04_still_energy
+        filters:
+          - throttle: 500ms
     g5:
       move_energy:
         name: LD2412 g05 move energy
         id: ld2412_g05_move_energy
+        filters:
+          - throttle: 500ms
       still_energy:
         name: LD2412 g05 still energy
         id: ld2412_g05_still_energy
+        filters:
+          - throttle: 500ms
     g6:
       move_energy:
         name: LD2412 g06 move energy
         id: ld2412_g06_move_energy
+        filters:
+          - throttle: 500ms
       still_energy:
         name: LD2412 g06 still energy
         id: ld2412_g06_still_energy
+        filters:
+          - throttle: 500ms
     g7:
       move_energy:
         name: LD2412 g07 move energy
         id: ld2412_g07_move_energy
+        filters:
+          - throttle: 500ms
       still_energy:
         name: LD2412 g07 still energy
         id: ld2412_g07_still_energy
+        filters:
+          - throttle: 500ms
     g8:
       move_energy:
         name: LD2412 g08 move energy
         id: ld2412_g08_move_energy
+        filters:
+          - throttle: 500ms
       still_energy:
         name: LD2412 g08 still energy
         id: ld2412_g08_still_energy
+        filters:
+          - throttle: 500ms
     g9:
       move_energy:
         name: LD2412 g09 move energy
         id: ld2412_g09_move_energy
+        filters:
+          - throttle: 500ms
       still_energy:
         name: LD2412 g09 still energy
         id: ld2412_g09_still_energy
+        filters:
+          - throttle: 500ms
     g10:
       move_energy:
         name: LD2412 g10 move energy
         id: ld2412_g10_move_energy
+        filters:
+          - throttle: 500ms
       still_energy:
         name: LD2412 g10 still energy
         id: ld2412_g10_still_energy
+        filters:
+          - throttle: 500ms
     g11:
       move_energy:
         name: LD2412 g11 move energy
         id: ld2412_g11_move_energy
+        filters:
+          - throttle: 500ms
       still_energy:
         name: LD2412 g11 still energy
         id: ld2412_g11_still_energy
+        filters:
+          - throttle: 500ms
     g12:
       move_energy:
         name: LD2412 g12 move energy
         id: ld2412_g12_move_energy
+        filters:
+          - throttle: 500ms
       still_energy:
         name: LD2412 g12 still energy
         id: ld2412_g12_still_energy
+        filters:
+          - throttle: 500ms
     g13:
       move_energy:
         name: LD2412 g13 move energy
         id: ld2412_g13_move_energy
+        filters:
+          - throttle: 500ms
       still_energy:
         name: LD2412 g13 still energy
         id: ld2412_g13_still_energy
+        filters:
+          - throttle: 500ms
 
 select:
   - platform: LD2412


### PR DESCRIPTION
ESPHome 2025.8.0 has removed the throttle property in the LD2412 and ld2450 stanzas. Replace those with throttle filter settings on the sensors.

<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version: 2025.8.20.1

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## What does this implement/fix?
Fixes #27. Replace the global "throttle" setting with per-sensor throttle filters.


## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [X] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [X] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!--
  Thank you for contributing <3
-->


