### PR TITLE
ESPHome 2025.8.0 - LD2450 native filters

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -413,162 +413,102 @@ sensor:
     target_count:
       name: LD2450 Presence Target Count
       id: presence_target_count
-      filters:
-        - throttle: 500ms
     still_target_count:
       name: LD2450 Still Target Count
       id: ld2450_still_target_count
-      filters:
-        - throttle: 500ms
     moving_target_count:
       name: LD2450 Moving Target Count
       id: ld2450_moving_target_count
-      filters:
-        - throttle: 500ms
     target_1:
       x:
         name: LD2450 Target-1 X
         id: ld2450_target1_x
-        filters:
-          - throttle: 500ms
       y:
         name: LD2450 Target-1 Y
         id: ld2450_target1_y
-        filters:
-          - throttle: 500ms
       speed:
         name: LD2450 Target-1 Speed
         id: ld2450_target1_speed
-        filters:
-          - throttle: 500ms
       angle:
         name: LD2450 Target-1 Angle
         id: ld2450_target1_angle
-        filters:
-          - throttle: 500ms
       distance:
         name: LD2450 Target-1 Distance
         id: ld2450_target1_distance
-        filters:
-          - throttle: 500ms
       resolution:
         name: LD2450 Target-1 Resolution
         id: ld2450_target1_resolution
         disabled_by_default: true
-        filters:
-          - throttle: 500ms
     target_2:
       x:
         name: LD2450 Target-2 X
         id: ld2450_target2_x
-        filters:
-          - throttle: 500ms
       y:
         name: LD2450 Target-2 Y
         id: ld2450_target2_y
-        filters:
-          - throttle: 500ms
       speed:
         name: LD2450 Target-2 Speed
         id: ld2450_target2_speed
-        filters:
-          - throttle: 500ms
       angle:
         name: LD2450 Target-2 Angle
         id: ld2450_target2_angle
-        filters:
-          - throttle: 500ms
       distance:
         name: LD2450 Target-2 Distance
         id: ld2450_target2_distance
-        filters:
-          - throttle: 500ms
       resolution:
         name: LD2450 Target-2 Resolution
         id: ld2450_target2_resolution
         disabled_by_default: true
-        filters:
-          - throttle: 500ms
     target_3:
       x:
         name: LD2450 Target-3 X
         id: ld2450_target3_x
-        filters:
-          - throttle: 500ms
       y:
         name: LD2450 Target-3 Y
         id: ld2450_target3_y
-        filters:
-          - throttle: 500ms
       speed:
         name: LD2450 Target-3 Speed
         id: ld2450_target3_speed
-        filters:
-          - throttle: 500ms
       angle:
         name: LD2450 Target-3 Angle
         id: ld2450_target3_angle
-        filters:
-          - throttle: 500ms
       distance:
         name: LD2450 Target-3 Distance
         id: ld2450_target3_distance
-        filters:
-          - throttle: 500ms
       resolution:
         name: LD2450 Target-3 Resolution
         id: ld2450_target3_resolution
         disabled_by_default: true
-        filters:
-          - throttle: 500ms
     zone_1:
       target_count:
         name: LD2450 Zone-1 All Target Count
         id: ld2450_zone1_target_count
-        filters:
-          - throttle: 500ms
       still_target_count:
         name: LD2450 Zone-1 Still Target Count
         id: ld2450_zone1_still_target_count
-        filters:
-          - throttle: 500ms
       moving_target_count:
         name: LD2450 Zone-1 Moving Target Count
         id: ld2450_zone1_moving_target_count
-        filters:
-          - throttle: 500ms
     zone_2:
       target_count:
         name: LD2450 Zone-2 All Target Count
         id: ld2450_zone2_target_count
-        filters:
-          - throttle: 500ms
       still_target_count:
         name: LD2450 Zone-2 Still Target Count
         id: ld2450_zone2_still_target_count
-        filters:
-          - throttle: 500ms
       moving_target_count:
         name: LD2450 Zone-2 Moving Target Count
         id: ld2450_zone2_moving_target_count
-        filters:
-          - throttle: 500ms
     zone_3:
       target_count:
         name: LD2450 Zone-3 All Target Count
         id: ld2450_zone3_target_count
-        filters:
-          - throttle: 500ms
       still_target_count:
         name: LD2450 Zone-3 Still Target Count
         id: ld2450_zone3_still_target_count
-        filters:
-          - throttle: 500ms
       moving_target_count:
         name: LD2450 Zone-3 Moving Target Count
         id: ld2450_zone3_moving_target_count
-        filters:
-          - throttle: 500ms
 
   - platform: LD2412
     moving_distance:


### PR DESCRIPTION
<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version: "25.8.24.1"

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## What does this implement/fix?
ESPHome 2025.8.0 will not compile with the current Core.yaml file. It fails with: 

```
ld2450: [source /data/packages/4132d9b7/Integrations/ESPHome/Core.yaml:95]
  - id: ld2450_radar
    uart_id: uart_bus2
    
    throttle has been removed; use per-sensor filters, instead.
    throttle: 500ms
```

Reading the docs shows that each domain (switch, sensor, number, etc.) have filters with default values to not flood the HASS DB, so I removed the throttle filters and let the defaults be used.


## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!--
  Thank you for contributing <3
-->


