### PR TITLE
update ld2412 and ld2450 target entities with better names and better id names

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "25.8.20.2"
+  version: "25.9.18.1"
 
 esp32:
   board: esp32-s3-devkitc-1
@@ -326,14 +326,14 @@ binary_sensor:
   - platform: ld2450
     ld2450_id: ld2450_radar
     has_target:
-      id: has_target_bs
-      name: Presence
+      id: ld2450_presence
+      name: "LD2450 Presence"
     has_moving_target:
-      id: has_moving_target_bs
-      name: Moving Target
+      id: ld2450_moving_target
+      name: "LD2450 Moving Target"
     has_still_target:
-      id: has_still_target_bs
-      name: Still Target
+      id: ld2450_still_target
+      name: "LD2450 Still Target"
 
   - platform: status
     name: Online


### PR DESCRIPTION
discord user Mistar Muffin pointed out the names were not specific on ld2450 presence target entities.

I edited the names to match the same as LD2412 names and edited each entity ID for both ld2412/ld2450 to more accurately reflect the name of the entities.

https://discord.com/channels/1126966963206361199/1354841614178062417/1418203837310963712

<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version:

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## What does this implement/fix?



## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [ ] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!--
  Thank you for contributing <3
-->


