### PR TITLE
[esphome] Modernise board spec, web server v3, remove legacy options

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -2,7 +2,6 @@ substitutions:
   version: "25.11.20.1"
 
 esp32:
-  board: esp32-s3-devkitc-1
   variant: esp32s3
   flash_size: 8MB
   framework:
@@ -55,8 +54,9 @@ rtttl:
  id: rtttl_player
  output: buzzer
 
-web_server:  
+web_server:
   port: 80
+  version: 3
 
 i2c:
   sda: GPIO41

--- a/Integrations/ESPHome/R_PRO-1_ETH.yaml
+++ b/Integrations/ESPHome/R_PRO-1_ETH.yaml
@@ -4,9 +4,6 @@ esphome:
   friendly_name: Apollo R_PRO-1
   comment: Apollo R_PRO-1
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   project:
     name: "ApolloAutomation.R-PRO-1-ETH"
     version: ${version}

--- a/Integrations/ESPHome/R_PRO-1_W.yaml
+++ b/Integrations/ESPHome/R_PRO-1_W.yaml
@@ -4,9 +4,6 @@ esphome:
   friendly_name: Apollo R_PRO-1
   comment: Apollo R_PRO-1
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   project:
     name: "ApolloAutomation.R-PRO-1-W"
     version: ${version}
@@ -52,6 +49,7 @@ esp32_improv:
 
 web_server:
   port: 80
+  version: 3
 
 update:
   - platform: http_request
@@ -63,11 +61,6 @@ logger:
 
 wifi:
   id: wifi_1
-  on_connect:
-    - delay: 5s
-    - ble.disable:
-  on_disconnect:
-    - ble.enable:
   ap:
     ssid: "Apollo R PRO 1 Hotspot"
 


### PR DESCRIPTION
## Summary

- Remove redundant `esp32: board: esp32-s3-devkitc-1` string from Core.yaml (`variant: esp32s3` + `flash_size: 8MB` already present and sufficient)
- Add `version: 3` to `web_server:` in Core.yaml (used by ETH variant) and R_PRO-1_W.yaml (WiFi variant overrides)
- Remove `platformio_options: board_build.flash_mode: dio` from R_PRO-1_W.yaml and R_PRO-1_ETH.yaml (not needed when using variant/flash_size spec)
- Remove legacy BLE wifi hooks (`on_connect: ble.disable` / `on_disconnect: ble.enable`) from R_PRO-1_W.yaml

## Test plan

- [ ] `esphome config` validates cleanly for R_PRO-1_W.yaml and R_PRO-1_ETH.yaml
- [ ] OTA flash succeeds on a WiFi device
- [ ] OTA flash succeeds on an Ethernet device
- [ ] Web server UI loads at device IP on both variants

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing tests pass locally with my changes