### PR TITLE
[select] Fix deprecated .state property, use current_option()

### DIFF
--- a/Integrations/ESPHome/R_PRO-1_ETH.yaml
+++ b/Integrations/ESPHome/R_PRO-1_ETH.yaml
@@ -76,7 +76,7 @@ select:
       then:
         - if:
             condition:
-              lambda: 'return id(firmware_selector).state == "Ethernet";'
+              lambda: 'return id(firmware_selector).current_option() == "Ethernet";'
             then:
               - logger.log: "OTA updates set to use ethernet firmware"
               - lambda: id(update_http_request).set_source_url("https://apolloautomation.github.io/R_PRO-1/firmware-e/manifest.json");

--- a/Integrations/ESPHome/R_PRO-1_W.yaml
+++ b/Integrations/ESPHome/R_PRO-1_W.yaml
@@ -82,7 +82,7 @@ select:
       then:
         - if:
             condition:
-              lambda: 'return id(firmware_selector).state == "Ethernet";'
+              lambda: 'return id(firmware_selector).current_option() == "Ethernet";'
             then:
               - logger.log: "OTA updates set to use ethernet firmware"
               - lambda: id(update_http_request).set_source_url("https://apolloautomation.github.io/R_PRO-1/firmware-e/manifest.json");


### PR DESCRIPTION
<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version:

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## What does this implement/fix?

Replaces deprecated `Select::state` with `current_option()` in two files. ESPHome 2026.1.0 deprecated `esphome::select::Select::state` and it will be removed in ESPHome 2026.7.0.

- `R_PRO-1_ETH.yaml` line 79: `id(firmware_selector).state` → `id(firmware_selector).current_option()`
- `R_PRO-1_W.yaml` line 85: `id(firmware_selector).state` → `id(firmware_selector).current_option()`

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!--
  Thank you for contributing <3
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved firmware selection detection logic in device configurations to use the correct method for identifying the currently selected firmware option. This ensures OTA updates trigger properly with the right configuration settings for both Ethernet and WiFi device variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->