### PR TITLE
Add combined Presence binary sensor

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -386,6 +386,13 @@ binary_sensor:
       name: "LD2412 Still Target"
       id: ld2412_still_target
 
+  - platform: template
+    name: "Presence"
+    id: combined_presence
+    device_class: occupancy
+    lambda: |-
+      return id(ld2450_presence).state || id(ld2412_presence).state;
+
 sensor:
   - platform: internal_temperature
     name: "ESP Temperature"

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -387,7 +387,7 @@ binary_sensor:
       id: ld2412_still_target
 
   - platform: template
-    name: "Presence"
+    name: "Combined Presence"
     id: combined_presence
     device_class: occupancy
     lambda: |-


### PR DESCRIPTION
## Summary
- Adds a template binary sensor named \`Presence\` with \`device_class: occupancy\`
- Combines LD2450 and LD2412 presence detection via OR logic — if either radar detects someone, the sensor is \`on\`
- Provides a single clean presence entity to use in automations and dashboards

## Test plan
- [ ] Flash firmware and confirm \`Presence\` entity appears in HA under the device
- [ ] Verify sensor turns \`on\` when either LD2450 or LD2412 detects presence
- [ ] Verify sensor turns \`off\` when both radars report no presence

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new combined Presence sensor that consolidates occupancy detection from multiple presence sources into a single unified indicator.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->