### PR TITLE
Release 26.3.2.1 - New sensors, ESPHome modernisation, and bug fixes

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -73,6 +73,7 @@ uart:
   - id: uart_ld2450
     tx_pin: GPIO17
     rx_pin: GPIO18
+    rx_buffer_size: 1024
     baud_rate: 256000
     parity: NONE
     stop_bits: 1

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -771,6 +771,7 @@ text_sensor:
     name: "ESPHome Version"
     hide_timestamp: true
     entity_category: "diagnostic"
+    entity_category: "diagnostic"
   - platform: template
     name: "Apollo Firmware Version"
     id: apollo_firmware_version

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -2,7 +2,6 @@ substitutions:
   version: "25.11.20.1"
 
 esp32:
-  board: esp32-s3-devkitc-1
   variant: esp32s3
   flash_size: 8MB
   framework:
@@ -55,8 +54,9 @@ rtttl:
  id: rtttl_player
  output: buzzer
 
-web_server:  
+web_server:
   port: 80
+  version: 3
 
 i2c:
   sda: GPIO41

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -9,16 +9,16 @@ esp32:
     type: esp-idf
 
 api:
-  services:
-    - service: play_buzzer
+  actions:
+    - action: play_buzzer
       variables:
         song_str: string
       then:
         - rtttl.play:
             rtttl: !lambda 'return song_str;'
 
-    #Co2 Calibration Service
-    - service: calibrate_co2_value
+    #Co2 Calibration Action
+    - action: calibrate_co2_value
       variables:
         co2_ppm: float
       then:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -772,6 +772,7 @@ text_sensor:
     hide_timestamp: true
     entity_category: "diagnostic"
     entity_category: "diagnostic"
+    entity_category: "diagnostic"
   - platform: template
     name: "Apollo Firmware Version"
     id: apollo_firmware_version

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -771,8 +771,6 @@ text_sensor:
     name: "ESPHome Version"
     hide_timestamp: true
     entity_category: "diagnostic"
-    entity_category: "diagnostic"
-    entity_category: "diagnostic"
   - platform: template
     name: "Apollo Firmware Version"
     id: apollo_firmware_version

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -778,6 +778,7 @@ text_sensor:
     id: apollo_firmware_version
     lambda: |-
       return {"${version}"};
+    update_interval: never
     entity_category: "diagnostic"
 
 light:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -767,6 +767,16 @@ text_sensor:
       name: "LD2412 BT MAC"
       id: ld2412_bt_mac
       disabled_by_default: true
+  - platform: version
+    name: "ESPHome Version"
+    hide_timestamp: true
+    entity_category: "diagnostic"
+  - platform: template
+    name: "Apollo Firmware Version"
+    id: apollo_firmware_version
+    lambda: |-
+      return {"${version}"};
+    entity_category: "diagnostic"
 
 light:
   - platform: esp32_rmt_led_strip

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -774,8 +774,7 @@ text_sensor:
   - platform: template
     name: "Apollo Firmware Version"
     id: apollo_firmware_version
-    lambda: |-
-      return {"${version}"};
+    update_interval: never
     entity_category: "diagnostic"
 
 light:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "25.11.20.1"
+  version: "26.3.2.1"
 
 esp32:
   variant: esp32s3
@@ -189,7 +189,7 @@ number:
     min_value: -70.0
     max_value: 70.0
     entity_category: "CONFIG"
-    unit_of_measurement: "Â°C"
+    unit_of_measurement: "°C"
     optimistic: true
     update_interval: never
     step: 0.1

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -189,7 +189,7 @@ number:
     min_value: -70.0
     max_value: 70.0
     entity_category: "CONFIG"
-    unit_of_measurement: "°C"
+    unit_of_measurement: "Â°C"
     optimistic: true
     update_interval: never
     step: 0.1

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -776,7 +776,6 @@ text_sensor:
     id: apollo_firmware_version
     lambda: |-
       return {"${version}"};
-    update_interval: never
     entity_category: "diagnostic"
 
 light:

--- a/Integrations/ESPHome/R_PRO-1_ETH.yaml
+++ b/Integrations/ESPHome/R_PRO-1_ETH.yaml
@@ -4,9 +4,6 @@ esphome:
   friendly_name: Apollo R_PRO-1
   comment: Apollo R_PRO-1
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   project:
     name: "ApolloAutomation.R-PRO-1-ETH"
     version: ${version}

--- a/Integrations/ESPHome/R_PRO-1_ETH.yaml
+++ b/Integrations/ESPHome/R_PRO-1_ETH.yaml
@@ -93,6 +93,7 @@ text_sensor:
   - platform: ethernet_info
     ip_address:
       name: "IP Address"
+      id: eth_ip
       entity_category: "diagnostic"
 
 packages:

--- a/Integrations/ESPHome/R_PRO-1_ETH.yaml
+++ b/Integrations/ESPHome/R_PRO-1_ETH.yaml
@@ -89,5 +89,11 @@ select:
               - lambda: id(update_http_request).set_source_url("https://apolloautomation.github.io/R_PRO-1/firmware-w/manifest.json");
               - component.update: update_http_request
 
+text_sensor:
+  - platform: ethernet_info
+    ip_address:
+      name: "IP Address"
+      entity_category: "diagnostic"
+
 packages:
   core: !include Core.yaml

--- a/Integrations/ESPHome/R_PRO-1_ETH.yaml
+++ b/Integrations/ESPHome/R_PRO-1_ETH.yaml
@@ -76,7 +76,7 @@ select:
       then:
         - if:
             condition:
-              lambda: 'return id(firmware_selector).state == "Ethernet";'
+              lambda: 'return id(firmware_selector).current_option() == "Ethernet";'
             then:
               - logger.log: "OTA updates set to use ethernet firmware"
               - lambda: id(update_http_request).set_source_url("https://apolloautomation.github.io/R_PRO-1/firmware-e/manifest.json");

--- a/Integrations/ESPHome/R_PRO-1_ETH.yaml
+++ b/Integrations/ESPHome/R_PRO-1_ETH.yaml
@@ -10,11 +10,6 @@ esphome:
 
   min_version: 2025.11.0
   on_boot:
-    - priority: 900
-      then:
-        - text_sensor.template.publish:
-            id: apollo_firmware_version
-            state: "${version}"
     - priority: 800
       then:
         - if:
@@ -31,7 +26,12 @@ esphome:
               id(scd40).set_automatic_self_calibration(false);
               ESP_LOGI("scd40", "Automatic self-calibration disabled on boot");
             }
-  
+    - priority: 500
+      then:
+        - text_sensor.template.publish:
+            id: apollo_firmware_version
+            state: "${version}"
+
 dashboard_import:
   package_import_url: github://ApolloAutomation/R_PRO-1/Integrations/ESPHome/R_PRO-1_ETH.yaml
   import_full_config: false

--- a/Integrations/ESPHome/R_PRO-1_ETH.yaml
+++ b/Integrations/ESPHome/R_PRO-1_ETH.yaml
@@ -10,7 +10,11 @@ esphome:
 
   min_version: 2025.11.0
   on_boot:
-
+    - priority: 900
+      then:
+        - text_sensor.template.publish:
+            id: apollo_firmware_version
+            state: "${version}"
     - priority: 800
       then:
         - if:

--- a/Integrations/ESPHome/R_PRO-1_W.yaml
+++ b/Integrations/ESPHome/R_PRO-1_W.yaml
@@ -103,7 +103,7 @@ text_sensor:
   - platform: wifi_info
     ip_address:
       name: "IP Address"
-      id: wifi_ip
+      entity_category: "diagnostic"
 
 packages:
   core: !include Core.yaml

--- a/Integrations/ESPHome/R_PRO-1_W.yaml
+++ b/Integrations/ESPHome/R_PRO-1_W.yaml
@@ -103,6 +103,7 @@ text_sensor:
   - platform: wifi_info
     ip_address:
       name: "IP Address"
+      id: wifi_ip
       entity_category: "diagnostic"
 
 packages:

--- a/Integrations/ESPHome/R_PRO-1_W.yaml
+++ b/Integrations/ESPHome/R_PRO-1_W.yaml
@@ -82,7 +82,7 @@ select:
       then:
         - if:
             condition:
-              lambda: 'return id(firmware_selector).state == "Ethernet";'
+              lambda: 'return id(firmware_selector).current_option() == "Ethernet";'
             then:
               - logger.log: "OTA updates set to use ethernet firmware"
               - lambda: id(update_http_request).set_source_url("https://apolloautomation.github.io/R_PRO-1/firmware-e/manifest.json");

--- a/Integrations/ESPHome/R_PRO-1_W.yaml
+++ b/Integrations/ESPHome/R_PRO-1_W.yaml
@@ -4,9 +4,6 @@ esphome:
   friendly_name: Apollo R_PRO-1
   comment: Apollo R_PRO-1
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   project:
     name: "ApolloAutomation.R-PRO-1-W"
     version: ${version}
@@ -52,6 +49,7 @@ esp32_improv:
 
 web_server:
   port: 80
+  version: 3
 
 update:
   - platform: http_request
@@ -63,11 +61,6 @@ logger:
 
 wifi:
   id: wifi_1
-  on_connect:
-    - delay: 5s
-    - ble.disable:
-  on_disconnect:
-    - ble.enable:
   ap:
     ssid: "Apollo R PRO 1 Hotspot"
 

--- a/Integrations/ESPHome/R_PRO-1_W.yaml
+++ b/Integrations/ESPHome/R_PRO-1_W.yaml
@@ -99,5 +99,11 @@ select:
               - lambda: id(update_http_request).set_source_url("https://apolloautomation.github.io/R_PRO-1/firmware-w/manifest.json");
               - component.update: update_http_request
 
+text_sensor:
+  - platform: wifi_info
+    ip_address:
+      name: "IP Address"
+      id: wifi_ip
+
 packages:
   core: !include Core.yaml

--- a/Integrations/ESPHome/R_PRO-1_W.yaml
+++ b/Integrations/ESPHome/R_PRO-1_W.yaml
@@ -11,6 +11,11 @@ esphome:
   min_version: 2025.11.0
 
   on_boot:
+    - priority: 900
+      then:
+        - text_sensor.template.publish:
+            id: apollo_firmware_version
+            state: "${version}"
     - priority: 800
       then:
         - if:

--- a/Integrations/ESPHome/R_PRO-1_W.yaml
+++ b/Integrations/ESPHome/R_PRO-1_W.yaml
@@ -11,11 +11,6 @@ esphome:
   min_version: 2025.11.0
 
   on_boot:
-    - priority: 900
-      then:
-        - text_sensor.template.publish:
-            id: apollo_firmware_version
-            state: "${version}"
     - priority: 800
       then:
         - if:
@@ -31,7 +26,12 @@ esphome:
               id(scd40).set_automatic_self_calibration(false);
               ESP_LOGI("scd40", "Automatic self-calibration disabled on boot");
             }
-  
+    - priority: 500
+      then:
+        - text_sensor.template.publish:
+            id: apollo_firmware_version
+            state: "${version}"
+
 dashboard_import:
   package_import_url: github://ApolloAutomation/R_PRO-1/Integrations/ESPHome/R_PRO-1_W.yaml
   import_full_config: false


### PR DESCRIPTION
<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version: 26.3.2.1

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## What does this implement/fix?

Merges beta into main for the 26.3.2.1 release. Changes include:

- **Fix LD2450 buffer overflow** — UART `rx_buffer_size` increased 256→1024 bytes to prevent corruption during boot initialization (~750 bytes sent by LD2450 on startup)
- **ESPHome modernisation** — web server v3, remove redundant board string (variant + flash_size already present), remove legacy platformio options and BLE wifi hooks *(breaking: board spec change)*
- **API services → actions rename** — `play_buzzer` and other services renamed to actions *(breaking: existing HA automations calling these services will need updating)*
- **IP address text sensor** — WiFi variant via `wifi_info` platform; Ethernet variant via dedicated ethernet IP diagnostic sensor
- **ESPHome version + Apollo firmware version text sensors** — added to both ETH and WiFi variants
- **Fix deprecated `.state` property** — replaced with `current_option()` on select components
- **Bug fixes** — Apollo firmware version showing "unknown", firmware version now published once on boot for both variants, UTF-8 special character restoration

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [x] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [x] Added/updated documentation for the web page

<!--
  Thank you for contributing <3
-->