### PR TITLE
Disable LD2450 Bluetooth by default on boot

### DIFF
--- a/Integrations/ESPHome/R_PRO-1_ETH.yaml
+++ b/Integrations/ESPHome/R_PRO-1_ETH.yaml
@@ -26,6 +26,10 @@ esphome:
               id(scd40).set_automatic_self_calibration(false);
               ESP_LOGI("scd40", "Automatic self-calibration disabled on boot");
             }
+    - priority: -100
+      then:
+        # Disable LD2450 Bluetooth by default on boot
+        - switch.turn_off: ld2450_bluetooth
     - priority: 500
       then:
         - text_sensor.template.publish:

--- a/Integrations/ESPHome/R_PRO-1_W.yaml
+++ b/Integrations/ESPHome/R_PRO-1_W.yaml
@@ -26,6 +26,10 @@ esphome:
               id(scd40).set_automatic_self_calibration(false);
               ESP_LOGI("scd40", "Automatic self-calibration disabled on boot");
             }
+    - priority: -100
+      then:
+        # Disable LD2450 Bluetooth by default on boot
+        - switch.turn_off: ld2450_bluetooth
     - priority: 500
       then:
         - text_sensor.template.publish:


### PR DESCRIPTION
Checks:
- [ ] Documentation Updated
- [ ] Build Number Incremented In MSR-1.yaml
- [ ] Build Number Incremented In manifest.json
- [ ] firmware-factory.bin Updated

## Summary
Fixes #54 - freshly flashed R_PRO-1 units were coming up with LD2450 Bluetooth enabled in Home Assistant. This adds an `on_boot` action (priority `-100`, so it runs after the `ld2450_bluetooth` switch is set up) that sends a turn-off command to the radar. Applied to both the Ethernet and WiFi variants.

## Why `-100` priority
The existing `800` block handles SCD40 calibration setup during bus init. A late priority (`-100`) ensures the LD2450 component is fully initialized before we send the switch command, so the turn-off actually reaches the radar module.

## Test plan
- [ ] Flash factory firmware on a bench unit, confirm LD2450 Bluetooth shows as `off` in HA after first boot
- [ ] Manually toggle LD2450 Bluetooth on, reboot, confirm it returns to `off`
- [ ] Verify no regression on SCD40 auto-calibration or firmware-version publish behavior