### PR TITLE
Make CO2 auto calibration toggle work at runtime

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -422,6 +422,7 @@ sensor:
       disabled_by_default: true
       filters:
         - lambda: return x - id(scd40_humidity_offset).state;
+    automatic_self_calibration: true
     update_interval: 60s
     measurement_mode: "periodic"
     i2c_id: bus_a
@@ -730,17 +731,22 @@ switch:
     entity_category: "config"
 
   - platform: template
-    name: "SCD40 Automatic Self Calibration"
-    id: scd40_auto_self_calibration
-    icon: mdi:tune
+    name: "CO2 Auto Calibration"
+    id: co2_auto_calibration
+    icon: mdi:molecule-co2
     restore_mode: RESTORE_DEFAULT_ON
-    disabled_by_default: true
     optimistic: true
     entity_category: "config"
     on_turn_on:
-      - lambda: 'id(scd40).set_automatic_self_calibration(true);'
+      then:
+        - script.execute:
+            id: setCo2AutoCalibration
+            enable: true
     on_turn_off:
-      - lambda: 'id(scd40).set_automatic_self_calibration(false);'
+      then:
+        - script.execute:
+            id: setCo2AutoCalibration
+            enable: false
 
 text_sensor:
   - platform: ld2450
@@ -808,6 +814,36 @@ light:
           max_brightness: 100%
 
 script:
+  - id: setCo2AutoCalibration
+    mode: restart
+    parameters:
+      enable: bool
+    then:
+      #The SCD40 forgets this setting on power loss and the scd4x component
+      #re-applies the YAML default during setup (~1.5s after boot), so when this
+      #runs at boot (via the restored switch state) wait for setup to finish first.
+      - if:
+          condition:
+            lambda: "return millis() < 20000;"
+          then:
+            - delay: 20s
+      #The sensor only accepts the ASC command while idle, so stop periodic
+      #measurement first, then restart it. Same sequence the component uses
+      #for forced calibration.
+      - lambda: |-
+          id(scd40).write_command((uint16_t) 0x3F86); //stop periodic measurement
+      - delay: 500ms
+      - lambda: |-
+          id(scd40).set_automatic_self_calibration(enable);
+          if (!id(scd40).write_command((uint16_t) 0x2416, (uint16_t) (enable ? 1 : 0))) {
+            ESP_LOGE("Apollo", "Failed to set CO2 auto calibration");
+          } else {
+            ESP_LOGI("Apollo", "CO2 auto calibration %s", enable ? "enabled" : "disabled");
+          }
+      - delay: 10ms
+      - lambda: |-
+          id(scd40).write_command((uint16_t) 0x21B1); //start periodic measurement
+
   - id: statusCheck
     then:
       - if:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "26.3.2.1"
+  version: "26.6.10.1"
 
 esp32:
   variant: esp32s3

--- a/Integrations/ESPHome/R_PRO-1_ETH.yaml
+++ b/Integrations/ESPHome/R_PRO-1_ETH.yaml
@@ -17,15 +17,6 @@ esphome:
               - lambda: "return id(runTest);"
             then:
               - lambda: "id(testScript).execute();"
-        # Check and apply SCD40 auto self-calibration setting
-        - lambda: |-
-            if (id(scd40_auto_self_calibration).state) {
-              id(scd40).set_automatic_self_calibration(true);
-              ESP_LOGI("scd40", "Automatic self-calibration enabled on boot");
-            } else {
-              id(scd40).set_automatic_self_calibration(false);
-              ESP_LOGI("scd40", "Automatic self-calibration disabled on boot");
-            }
     - priority: -100
       then:
         # Disable LD2450 Bluetooth by default on boot

--- a/Integrations/ESPHome/R_PRO-1_W.yaml
+++ b/Integrations/ESPHome/R_PRO-1_W.yaml
@@ -18,14 +18,6 @@ esphome:
               - lambda: "return id(runTest);"
             then:
               - lambda: "id(testScript).execute();"
-        - lambda: |-
-            if (id(scd40_auto_self_calibration).state) {
-              id(scd40).set_automatic_self_calibration(true);
-              ESP_LOGI("scd40", "Automatic self-calibration enabled on boot");
-            } else {
-              id(scd40).set_automatic_self_calibration(false);
-              ESP_LOGI("scd40", "Automatic self-calibration disabled on boot");
-            }
     - priority: -100
       then:
         # Disable LD2450 Bluetooth by default on boot


### PR DESCRIPTION
﻿<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version: 26.6.10.1

## What does this implement/fix?

Makes the CO2 auto calibration toggle actually work at runtime, and renames it for consistency with the other SCD40 products.

- The existing "SCD40 Automatic Self Calibration" switch only set the scd4x component's in-memory flag, which is not written to the sensor until the next reboot. It was also hidden (`disabled_by_default: true`). The replacement "CO2 Auto Calibration" switch (same name as the new AIR-1/MSR-2/MTR-1 switch) is visible by default and takes effect immediately: the script stops periodic measurement, sends the ASC command over I2C, and restarts measurement. The saved choice is re-applied ~20 seconds after every boot.
- The `on_boot` re-apply lambdas in R_PRO-1_W.yaml and R_PRO-1_ETH.yaml are removed; the restored switch state now handles boot re-apply through the same script (one mechanism instead of two).
- `automatic_self_calibration: true` is now set explicitly instead of relying on the ESPHome default, so there is **no calibration behavior change**: ASC was already on by default for the R_PRO-1.
- Version bumped to 26.6.10.1.

**Migration caveat for release notes (why this is marked breaking):** the entity rename breaks any automation or dashboard referencing the old switch entity, and means a previously saved switch state does not carry over; devices fall back to the default (on) after updating. Anyone who had the old hidden switch turned off needs to turn the new one off once. Small audience, since the old switch was hidden and required a reboot to act.

This is part of the same rollout as AIR-1, MSR-2, and MTR-1 (which flip ASC from off to on and gain the same switch). A wiki update covering all four products is ready to merge alongside the firmware releases.

Verification: `esphome compile` passes for R_PRO-1_W.yaml and R_PRO-1_ETH.yaml (ESPHome 2026.1.3). Not yet tested on hardware.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [x] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [x] Added/updated documentation for the web page

<!--
  Thank you for contributing <3
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)


