### PR TITLE
Fix label-check and auto-assign on fork PRs

### DIFF
--- a/.github/workflows/autoassign.yml
+++ b/.github/workflows/autoassign.yml
@@ -1,8 +1,11 @@
 name: Auto Assign
+# pull_request_target (not pull_request) so assignment works on
+# fork-submitted PRs; fork pull_request runs get a read-only token.
+# Safe because this workflow never checks out or executes PR code.
 on:
   issues:
     types: [opened]
-  pull_request:
+  pull_request_target:
     types: [opened]
 jobs:
   run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,17 +4,10 @@ on:
   pull_request:
 
 permissions:
-  # Allow GITHUB_TOKEN to add labels to pull requests
-  pull-requests: write
-  issues: write
   contents: read
   id-token: write
 
 jobs:
-  label-check:
-    name: Label Check
-    uses: ApolloAutomation/Workflows/.github/workflows/label-check.yml@main
-    
   ci:
     name: Building ${{ matrix.file }} / ESPHome ${{ matrix.esphome-version }}
     runs-on: ubuntu-latest

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -1,0 +1,20 @@
+name: Label Check
+
+# pull_request_target (not pull_request) so the job gets a write token on
+# fork-submitted PRs too; plain pull_request runs from forks are read-only
+# and cannot add labels. Safe because the called workflow only reads the PR
+# body and never checks out or executes PR code. The "edited" type re-runs
+# the check when the template checkboxes are changed.
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  label-check:
+    name: Label Check
+    uses: ApolloAutomation/Workflows/.github/workflows/label-check.yml@main


### PR DESCRIPTION
<!--
From Core.yaml. Should match date YY.MM.DD.# ( Usually # is 1 )
-->
Version: N/A (workflows only, does not publish)

## What does this implement/fix?

Fixes the Label Check and Auto Assign failures on fork-submitted PRs (seen on the CO2 auto calibration PR).

Workflows triggered by `pull_request` from a fork run with a read-only token, so `actions-ecosystem/action-add-labels` and `pozil/auto-assign-issue` fail with `403 Resource not accessible by integration`. Moving those two jobs to `pull_request_target` runs them in the base repo's context with a write token.

- Label Check moves out of `ci.yml` into its own `label-check.yml` on `pull_request_target` (with `edited` in the trigger types, so fixing a checkbox re-runs the check). The firmware build jobs stay on `pull_request`, since they compile PR-controlled YAML and must never get a write token.
- `autoassign.yml` switches its PR trigger to `pull_request_target` (issues trigger unchanged).
- `ci.yml` permissions are trimmed to what the build jobs need.

This is safe because neither moved job checks out or executes PR code. Depends on ApolloAutomation/Workflows#24, which hardens the reusable label-check against script injection from the PR body; that PR should merge first.

Same fix is going to AIR-1, MSR-2, MTR-1, and R_PRO-1.

## Types of changes
<!--
  What type of change does your PR introduce?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Bugfix (fixed change that fixes an issue)
- [ ] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [x] Github workflows - Does not publish

## Checklist / Checklijst:
<!--
  Put an x in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

  - [ ] The code change has been tested and works locally
  - [x] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!--
  Thank you for contributing <3
-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
