### PR TITLE
Fix firmware update entity being stale for 6h after boot

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,6 +2,7 @@ name-template: 'Release v$NEXT_PATCH_VERSION'
 tag-template: "$RESOLVED_VERSION"
 change-template: "- #$NUMBER $TITLE @$AUTHOR"
 sort-direction: ascending
+category-template: '**$TITLE**'
 
 categories:
   - title: "🚨 Breaking changes"
@@ -41,11 +42,9 @@ include-labels:
 
 no-changes-template: '- No changes'
 
+# The shared build workflow appends a Full Changelog compare link to the
+# release body (release-drafter cannot render 4-part version tags).
 template: |
-  ## What's Changed
+  **What's Changed**
 
   $CHANGES
-
-  **Full Changelog**: https://github.com/ApolloAutomation/R_PRO-1/compare/$PREVIOUS_TAG...$RESOLVED_VERSION.1
-
-   Be sure to 🌟 this repository for updates!

--- a/Integrations/ESPHome/R_PRO-1_ETH.yaml
+++ b/Integrations/ESPHome/R_PRO-1_ETH.yaml
@@ -10,6 +10,13 @@ esphome:
 
   min_version: 2025.11.0
   on_boot:
+    - priority: -100
+      then:
+        - wait_until:
+            condition:
+              lambda: return network::is_connected();
+            timeout: 60s
+        - component.update: update_http_request
     - priority: 800
       then:
         - if:

--- a/Integrations/ESPHome/R_PRO-1_W.yaml
+++ b/Integrations/ESPHome/R_PRO-1_W.yaml
@@ -69,6 +69,8 @@ update:
 logger:
 
 wifi:
+  on_connect:
+    - component.update: update_http_request
   id: wifi_1
   ap:
     ssid: "Apollo R PRO 1 Hotspot"


### PR DESCRIPTION
The `update: http_request` component polls the manifest every 6 hours, and its first poll fires during boot **before the network is up**. When that happens it logs "Network not connected, skipping update check" and silently waits for the next 6-hour tick — so for ~6 hours after every boot/power cycle the Firmware Update entity shows stale information even when an update is published.

## Changes

- **R_PRO-1_W**: manifest check triggered on `wifi.on_connect`
- **R_PRO-1_ETH**: `ethernet:` doesn't support `on_connect`, so a low-priority `on_boot` hook waits (up to 60s) for `network::is_connected()` and then checks

Both variants compile-verified on ESPHome 2026.1.3 (ETH full compile to exercise the lambda).

Found and verified on physical hardware while porting this update system to MTR-1 (the fix is included in the MTR-1/AIR-1/MSR-1/MSR-2 ports).