### PR TITLE
Standardize pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -45,5 +45,3 @@ If user-visible functionality or configuration variables are added/modified:
 <!--
   Thank you for contributing <3
 -->
-
-

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,0 @@
-Checks:
-- [ ] Documentation Updated
-- [ ] Build Number Incremented In MSR-1.yaml
-- [ ] Build Number Incremented In manifest.json
-- [ ] firmware-factory.bin Updated


### PR DESCRIPTION
Standardizes this repo's pull request template to match the shared template used across the Apollo product repos (PUMP-1, MTR-1, H-2, etc.).

The old template was copied from an early MSR-1 template and referenced files that don't exist in this repo (`MSR-1.yaml`, `manifest.json`, `firmware-factory.bin`).

- Moves it to `.github/PULL_REQUEST_TEMPLATE.md` (GitHub's conventional location; keeps the repo root clean)
- Adopts the shared `Types of changes` template

No firmware change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)