### PR TITLE
Replace deprecated rgb_order with channel_colors

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -798,7 +798,7 @@ light:
     default_transition_length: 0s
     chipset: WS2812
     num_leds: 4
-    rgb_order: grb
+    channel_colors: GRB
     effects:
       - pulse:
           name: "Slow Pulse"

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,5 +1,5 @@
 substitutions:
-  version: "26.6.10.1"
+  version: "26.8.27.1"
 
 esp32:
   variant: esp32s3

--- a/Integrations/ESPHome/R_PRO-1_ETH.yaml
+++ b/Integrations/ESPHome/R_PRO-1_ETH.yaml
@@ -8,7 +8,7 @@ esphome:
     name: "ApolloAutomation.R-PRO-1-ETH"
     version: ${version}
 
-  min_version: 2025.11.0
+  min_version: 2026.8.0
   on_boot:
     - priority: -100
       then:

--- a/Integrations/ESPHome/R_PRO-1_W.yaml
+++ b/Integrations/ESPHome/R_PRO-1_W.yaml
@@ -8,7 +8,7 @@ esphome:
     name: "ApolloAutomation.R-PRO-1-W"
     version: ${version}
 
-  min_version: 2025.11.0
+  min_version: 2026.8.0
 
   on_boot:
     - priority: 800


### PR DESCRIPTION
ESPHome 2026.8.0 replaces `rgb_order` / `is_rgbw` / `is_wrgb` with a single `channel_colors` key on `esp32_rmt_led_strip` ([esphome#18474](https://github.com/esphome/esphome/pull/18474)).

`channel_colors` takes each of `R`, `G`, `B` exactly once, optionally with a single `W`; the value is case-insensitive. No behaviour change — `grb` and `GRB` are equivalent, uppercase to match the ESPHome docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated RGB LED strip color channel configuration to use the current format, improving compatibility and ensuring colors display correctly.
* **Compatibility**
  * Updated ESPHome support requirements for Apollo R_PRO-1 Ethernet and wireless configurations.
  * Updated the ESPHome core version used by integrations to provide compatibility with newer releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->